### PR TITLE
Add glslify

### DIFF
--- a/bundler/webpack.common.js
+++ b/bundler/webpack.common.js
@@ -90,14 +90,13 @@ module.exports = {
                     filename: "assets/images/[hash][ext]"
                 }
             },
-            // {
-            //     test: /\.(glsl|vs|fs|vert|frag)$/,
-            //     exclude: /node_modules/,
-            //     use: [
-            //         "raw-loader",
-            //         "glslify-loader"
-            //     ]
-            // }
+            {
+                test: /\.(glsl|vs|fs|vert|frag)$/,
+                exclude: /node_modules/,
+                use: [
+                    "glslify-loader"
+                ]
+            }
         ]
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2952,6 +2952,11 @@
         "glsl-tokenizer": "^2.0.2"
       }
     },
+    "glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha1-NndF86MzgsDu7Ey1S36Zz8HXZws="
+    },
     "glsl-resolve": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "css-loader": "^6.5.0",
     "eslint": "^8.3.0",
     "file-loader": "^6.2.0",
+    "glsl-noise": "0.0.0",
     "glslify": "^7.1.1",
     "glslify-loader": "^2.0.0",
     "html-loader": "^3.0.0",

--- a/src/shaders/noise/1.frag
+++ b/src/shaders/noise/1.frag
@@ -1,49 +1,7 @@
 precision mediump float;
 uniform vec2 u_resolution;
 
-//  Classic Perlin 2D Noise
-//  by Stefan Gustavson
-//
-vec2 fade(vec2 t)
-{
-    return t*t*t*(t*(t*6.0-15.0)+10.0);
-}
-vec4 permute(vec4 x)
-{
-    return mod(((x*34.0)+1.0)*x, 289.0);
-}
-float cnoise(vec2 P)
-{
-    vec4 Pi = floor(P.xyxy) + vec4(0.0, 0.0, 1.0, 1.0);
-    vec4 Pf = fract(P.xyxy) - vec4(0.0, 0.0, 1.0, 1.0);
-    Pi = mod(Pi, 289.0); // To avoid truncation effects in permutation
-    vec4 ix = Pi.xzxz;
-    vec4 iy = Pi.yyww;
-    vec4 fx = Pf.xzxz;
-    vec4 fy = Pf.yyww;
-    vec4 i = permute(permute(ix) + iy);
-    vec4 gx = 2.0 * fract(i * 0.0243902439) - 1.0; // 1/41 = 0.024...
-    vec4 gy = abs(gx) - 0.5;
-    vec4 tx = floor(gx + 0.5);
-    gx = gx - tx;
-    vec2 g00 = vec2(gx.x,gy.x);
-    vec2 g10 = vec2(gx.y,gy.y);
-    vec2 g01 = vec2(gx.z,gy.z);
-    vec2 g11 = vec2(gx.w,gy.w);
-    vec4 norm = 1.79284291400159 - 0.85373472095314 * vec4(dot(g00, g00), dot(g01, g01), dot(g10, g10), dot(g11, g11));
-    g00 *= norm.x;
-    g01 *= norm.y;
-    g10 *= norm.z;
-    g11 *= norm.w;
-    float n00 = dot(g00, vec2(fx.x, fy.x));
-    float n10 = dot(g10, vec2(fx.y, fy.y));
-    float n01 = dot(g01, vec2(fx.z, fy.z));
-    float n11 = dot(g11, vec2(fx.w, fy.w));
-    vec2 fade_xy = fade(Pf.xy);
-    vec2 n_x = mix(vec2(n00, n01), vec2(n10, n11), fade_xy.x);
-    float n_xy = mix(n_x.x, n_x.y, fade_xy.y);
-    return 2.3 * n_xy;
-}
+#pragma glslify: cnoise = require('glsl-noise/classic/2d')
 
 void main() {
   vec2 st = gl_FragCoord.xy/u_resolution.xy;


### PR DESCRIPTION
Turns out that the "asset/source" bit just above the glslify loader was already doing the work raw-loader would be doing, and so all we had to do was not include raw-loader :)

One side effect of adding this is that the final output from glslify is shown on the page, rather than the original source. Sometimes this can be a bit messy, depending on the modules you're using and how they're being used.